### PR TITLE
Explicit count modifiers

### DIFF
--- a/Syntaxes/GAP.tmLanguage
+++ b/Syntaxes/GAP.tmLanguage
@@ -221,7 +221,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2})</string>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2})</string>
 					<key>name</key>
 					<string>constant.character.escape.gap</string>
 				</dict>


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by TextMate). This package is used to highlight GAP code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes and thus, the following code gets incorrectly highlighted.

``` gap
Error( "\00" );
```

This pull request fixes that by using an explicit count modifier in the regex.
