### PR TITLE
Add missing -> operator and atomic,readonly and readwrite keywords

### DIFF
--- a/Syntaxes/GAP.tmLanguage
+++ b/Syntaxes/GAP.tmLanguage
@@ -62,13 +62,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(in|and|or|not|mod|div)\b|\+|\-|\*|\/|\^|\~|\!\.|\=|&lt;&gt;|&lt;|&gt;|\.\.|:</string>
+			<string>\b(in|and|or|not|mod|div)\b|\-&gt;|\+|\-|\*|\/|\^|\~|\!\.|\=|&lt;&gt;|&lt;|&gt;|\.\.|:</string>
 			<key>name</key>
 			<string>keyword.operator</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(if|then|elif|else|while|for|return|where|do|case|when|repeat|until|break|continue|fi|od)\b</string>
+			<string>\b(if|then|elif|else|while|for|return|where|do|case|when|repeat|until|break|continue|fi|od|atomic|readonly|readwrite)\b</string>
 			<key>name</key>
 			<string>keyword.control</string>
 		</dict>


### PR DESCRIPTION
This adds the '->' operator for defining functions and the atomic, readonly and readwrite keywords.
